### PR TITLE
Firefox for Android support

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ in Safari.
 - Drag and drop the file "dqmsl.user.js" to a Firefox window.
 - Click the Install button.
 
+### Mozilla Firefox for Android
+
+- Install the extension USI. (https://addons.mozilla.org/zh-TW/firefox/addon/userunified-script-injector/)
+- In USI plugin settings, click "load Userscript" and load "dqmsl.user.js" manually.
+
 ## Uninstall
 
 Depending on the browser, perform the following steps to uninstall this

--- a/README.md
+++ b/README.md
@@ -47,7 +47,9 @@ in Safari.
 ### Mozilla Firefox for Android
 
 - Install the extension USI. (https://addons.mozilla.org/zh-TW/firefox/addon/userunified-script-injector/)
-- In USI plugin settings, click "load Userscript" and load "dqmsl.user.js" manually.
+- In "USI options", click "load Userscript"
+- In the "Direct Userscript Upload" section, click "Browse" and navigate to "dqmsl.user.js"
+- Click "Start" button.
 
 ## Uninstall
 

--- a/dqmsl.min.js
+++ b/dqmsl.min.js
@@ -201,3 +201,12 @@ function insertSkillDetails(a){for(var b in a){var c=a[b],d=c.src?c.src.match(/\
 function replace(a){if("undefined"==typeof a||null==a||0<=$.inArray(a,exceptions))return a;for(var b in groups){var c=new RegExp(groups[b].join("|"),"g");a=a.replace(c,function(a){return names[RegExp.escape(a)]})}return a}function subst(){var a=$("body").find(":not(iframe)").addBack().contents().filter(function(){return 3==this.nodeType}),b;for(b in a){var c=a[b];c.nodeValue=replace(c.nodeValue)}a=$("body").find("img");insertSkillDetails(a)}
 function twversion(){var a=$(location).attr("hostname"),b=$(location).attr("pathname"),c=$(location).attr("search");var d=c.match(/\?no=(\d+)/);var e="";null!=d&&(e=parseInt(d[1]));subst();if((d=$("#tokugiImageInfoPanel"))&&$(d).children("img").length>=options.skill_panel_image_resize_when){var k=parseInt($(d).css("width").replace(/px/));$(d).css("width",k*options.skill_panel_image_resize_factor+"px").children("img").css("width",100*options.skill_panel_image_resize_factor+"%")}"/monster/detail"==
 b&&(e in twmonsters?a==dqmsl_search_url&&displayOnDqmslSearch(e):e in monsters&&(document.title=monsters[e].cn));k=[{name:"system",doit:insertToDqmslSearchSystem},{name:"rank",doit:insertToDqmslSearchRank},{name:"type",doit:insertToDqmslSearchType}];for(var p in k){var n=k[p];b=="/picturebook/"+n.name&&(d=c.match(n.name+"=(\\d+)"),e=null,d&&(e=parseInt(d[1])),a==dqmsl_search_url&&n.doit(e))}}window.top==window.self&&$(twversion);
+
+// Quick and dirty solution for Android phones using Firefox with USI (User|Unified Script Injector) extension
+var ua = navigator.userAgent.toLowerCase();
+var isAndroid = ua.indexOf("android") > -1;
+if(isAndroid) {
+  // With USI, somehow window.top==window.self is NOT true (it is probably due to how USI implements this injection things...)
+  // So we simply run twversion() manually for Android devices
+  twversion();
+}

--- a/dqmsl.user.js
+++ b/dqmsl.user.js
@@ -4,6 +4,7 @@
 // @include     http://dqmsl-search.net/*
 // @include     http://dqmsl.jpn.org/*
 // @include     http://dqmsl.gamedbs.jp/*
+// @include-jquery true
 // @version     2017.7.31.0
 // @grant       none
 // @require     https://ajax.googleapis.com/ajax/libs/jquery/2.2.0/jquery.min.js
@@ -212,3 +213,12 @@ function insertSkillDetails(a){for(var b in a){var c=a[b],d=c.src?c.src.match(/\
 function replace(a){if("undefined"==typeof a||null==a||0<=$.inArray(a,exceptions))return a;for(var b in groups){var c=new RegExp(groups[b].join("|"),"g");a=a.replace(c,function(a){return names[RegExp.escape(a)]})}return a}function subst(){var a=$("body").find(":not(iframe)").addBack().contents().filter(function(){return 3==this.nodeType}),b;for(b in a){var c=a[b];c.nodeValue=replace(c.nodeValue)}a=$("body").find("img");insertSkillDetails(a)}
 function twversion(){var a=$(location).attr("hostname"),b=$(location).attr("pathname"),c=$(location).attr("search");var d=c.match(/\?no=(\d+)/);var e="";null!=d&&(e=parseInt(d[1]));subst();if((d=$("#tokugiImageInfoPanel"))&&$(d).children("img").length>=options.skill_panel_image_resize_when){var k=parseInt($(d).css("width").replace(/px/));$(d).css("width",k*options.skill_panel_image_resize_factor+"px").children("img").css("width",100*options.skill_panel_image_resize_factor+"%")}"/monster/detail"==
 b&&(e in twmonsters?a==dqmsl_search_url&&displayOnDqmslSearch(e):e in monsters&&(document.title=monsters[e].cn));k=[{name:"system",doit:insertToDqmslSearchSystem},{name:"rank",doit:insertToDqmslSearchRank},{name:"type",doit:insertToDqmslSearchType}];for(var p in k){var n=k[p];b=="/picturebook/"+n.name&&(d=c.match(n.name+"=(\\d+)"),e=null,d&&(e=parseInt(d[1])),a==dqmsl_search_url&&n.doit(e))}}window.top==window.self&&$(twversion);
+
+// Quick and dirty solution for Android phones using Firefox with USI (User|Unified Script Injector) extension
+var ua = navigator.userAgent.toLowerCase();
+var isAndroid = ua.indexOf("android") > -1;
+if(isAndroid) {
+  // With USI, somehow window.top==window.self is NOT true (it is probably due to how USI implements this injection things...)
+  // So we simply run twversion() manually for Android devices
+  twversion();
+}

--- a/firefox.header
+++ b/firefox.header
@@ -4,6 +4,7 @@
 // @include     http://dqmsl-search.net/*
 // @include     http://dqmsl.jpn.org/*
 // @include     http://dqmsl.gamedbs.jp/*
+// @include-jquery true
 // @version     2017.8.7.0
 // @grant       none
 // @require     https://ajax.googleapis.com/ajax/libs/jquery/2.2.0/jquery.min.js


### PR DESCRIPTION
With a few modifications, it is possible to use your translation script on a Android device using Firefox for Android with USI(User|Unified Script Injector) extension.
Link to the extension: https://addons.mozilla.org/zh-TW/firefox/addon/userunified-script-injector/?src=search

I've also attached a few screenshots showing how to enable it in Firefox for Android with USI installed.

![1](https://user-images.githubusercontent.com/21122311/30156808-414db26c-93f3-11e7-9ad1-3c3fc22e38de.jpg)
![2](https://user-images.githubusercontent.com/21122311/30156805-413ed6ac-93f3-11e7-8880-d3f6c9e57d0e.jpg)
![3](https://user-images.githubusercontent.com/21122311/30156807-4147dcd4-93f3-11e7-9d05-6b203dac8598.jpg)
![4](https://user-images.githubusercontent.com/21122311/30156806-41460e86-93f3-11e7-8c96-9cb99ebdcc5f.jpg)
